### PR TITLE
Change single quote docstring

### DIFF
--- a/clients/tests_models.py
+++ b/clients/tests_models.py
@@ -31,16 +31,14 @@ class ContactTestCase(ClientTestCase):
             client=starbucks)
 
     def test_contact_name(self):
-        '''
-            Tests if the objects are being created in the database and their __str__ func works
-        '''
+        """Tests if the objects are being created in the database and their __str__ func works
+        """
         client_instance = Contact.objects.get(name='Fernando')
         self.assertEqual(str(client_instance), 'Fernando Lobato Meeser')
 
     def test_relation_contact(self):
-        '''
-            Test if the contact objects are correctly referecing their clients.
-        '''
+        """Test if the contact objects are correctly referecing their clients.
+        """
         client_instance = Contact.objects.get(name='Fernando')
         starbucks = Client.objects.get(name='Test Starbucks')
         self.assertEqual(client_instance.client, starbucks)


### PR DESCRIPTION
Some docstrings for client model tests had single quotes instead of double.

#### What's this PR do?

Fixes docstring quotes for certain test methods on models.

#### Where should the reviewer start?

clients/test_models.py


#### How should this be manually tested?

python manage.py test
flake8


#### Any background context you want to provide?
Came from the following issue
https://github.com/fernandolobato/balarco/issues/8

This template was adapted ~stolen~ from [Quickleft/Sprint.ly](https://quickleft.com/blog/pull-request-templates-make-code-review-easier/)